### PR TITLE
fix: link CoreGraphics/UIKit/CoreImage/ImageIO in SwiftTasksVisionCore

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,6 +31,10 @@ let package = Package(
                 .linkedFramework("CoreVideo"),
                 .linkedFramework("AVFoundation"),
                 .linkedFramework("Accelerate"),
+                .linkedFramework("CoreGraphics"),
+                .linkedFramework("UIKit"),
+                .linkedFramework("CoreImage"),
+                .linkedFramework("ImageIO"),
                 .linkedLibrary("c++")
             ]
         ),


### PR DESCRIPTION
MediaPipeTasksVision image utils reference CoreGraphics + UIKit symbols; without these the package product fails to link into an app target (Undefined symbols: _CGBitmapContextCreate, _OBJC_CLASS_$_UIImage, ...).